### PR TITLE
fix: time with timezone UTC

### DIFF
--- a/app/database/models/cart.py
+++ b/app/database/models/cart.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 from sqlalchemy import UUID, DateTime, ForeignKey, Integer
@@ -18,7 +18,7 @@ class Cart(Base):
         UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), unique=True
     )
     total_items: Mapped[int] = mapped_column(Integer, default=0)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     user: Mapped["User"] = relationship(back_populates="cart")
     items: Mapped[List["CartItem"]] = relationship(

--- a/app/database/models/order.py
+++ b/app/database/models/order.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import List
 
@@ -22,9 +22,9 @@ class Order(Base):
     total_price: Mapped[Decimal] = mapped_column(
         Numeric(10, 2), nullable=False, default=0
     )
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc), nullable=False
     )
 
     user: Mapped["User"] = relationship(back_populates="orders")

--- a/app/database/models/product.py
+++ b/app/database/models/product.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Optional
 
@@ -23,7 +23,7 @@ class Product(Base):
     category_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID(as_uuid=True), ForeignKey("categories.id")
     )
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     category: Mapped[Optional["Category"]] = relationship(back_populates="products")
     product_rating: Mapped[Optional["ProductAverageRating"]] = relationship(

--- a/app/database/models/review.py
+++ b/app/database/models/review.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import (
     UUID,
@@ -33,7 +33,7 @@ class Review(Base):
     product_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("products.id")
     )
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     product: Mapped["Product"] = relationship()
     user: Mapped["User"] = relationship()

--- a/app/database/models/user.py
+++ b/app/database/models/user.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from sqlalchemy import UUID, DateTime, String
@@ -19,7 +19,7 @@ class User(Base):
     first_name: Mapped[Optional[str]] = mapped_column(String)
     last_name: Mapped[Optional[str]] = mapped_column(String)
     role: Mapped[str] = mapped_column(String, nullable=False, default="user")
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     cart: Mapped[Optional["Cart"]] = relationship(back_populates="user", uselist=False)
     orders: Mapped[List["Order"]] = relationship(back_populates="user")

--- a/app/services/user.py
+++ b/app/services/user.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from fastapi.security import OAuth2PasswordRequestForm
 from jose import jwt
@@ -48,7 +48,7 @@ async def login_serv(
 
 def create_access_token(data: dict, expires_delta: timedelta = None):
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    expire = datetime.now(timezone.utc) + (expires_delta or timedelta(minutes=15))
     to_encode.update({"exp": expire})
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
 

--- a/migrations/versions/2026_05_04_2135_created_at_with_timezone.py
+++ b/migrations/versions/2026_05_04_2135_created_at_with_timezone.py
@@ -1,0 +1,76 @@
+"""created_at with timezone
+
+Revision ID: 7f2cca8f2586
+Revises: 5b316576b7d8
+Create Date: 2026-05-04 21:35:08.327647
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '7f2cca8f2586'
+down_revision: Union[str, None] = '5b316576b7d8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL timezone = 'UTC'")
+
+    op.alter_column('carts', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               type_=sa.DateTime(timezone=True),
+               existing_nullable=False)
+    op.alter_column('orders', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               type_=sa.DateTime(timezone=True),
+               existing_nullable=False)
+    op.alter_column('orders', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               type_=sa.DateTime(timezone=True),
+               existing_nullable=False)
+    op.alter_column('products', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               type_=sa.DateTime(timezone=True),
+               existing_nullable=False)
+    op.alter_column('reviews', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               type_=sa.DateTime(timezone=True),
+               existing_nullable=False)
+    op.alter_column('users', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               type_=sa.DateTime(timezone=True),
+               existing_nullable=False)
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL timezone = 'UTC'")
+    
+    op.alter_column('users', 'created_at',
+               existing_type=sa.DateTime(timezone=True),
+               type_=postgresql.TIMESTAMP(),
+               existing_nullable=False)
+    op.alter_column('reviews', 'created_at',
+               existing_type=sa.DateTime(timezone=True),
+               type_=postgresql.TIMESTAMP(),
+               existing_nullable=False)
+    op.alter_column('products', 'created_at',
+               existing_type=sa.DateTime(timezone=True),
+               type_=postgresql.TIMESTAMP(),
+               existing_nullable=False)
+    op.alter_column('orders', 'updated_at',
+               existing_type=sa.DateTime(timezone=True),
+               type_=postgresql.TIMESTAMP(),
+               existing_nullable=False)
+    op.alter_column('orders', 'created_at',
+               existing_type=sa.DateTime(timezone=True),
+               type_=postgresql.TIMESTAMP(),
+               existing_nullable=False)
+    op.alter_column('carts', 'created_at',
+               existing_type=sa.DateTime(timezone=True),
+               type_=postgresql.TIMESTAMP(),
+               existing_nullable=False)

--- a/tests/api/test_product/test_api_product_listing.py
+++ b/tests/api/test_product/test_api_product_listing.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi import status
@@ -81,7 +81,7 @@ async def test_get_product_review_list_handler_without_cursor_success(
     product = product_factory()
     reviews = [
         review_factory(
-            product=product, created_at=datetime.utcnow() + timedelta(minutes=i)
+            product=product, created_at=datetime.now(timezone.utc) + timedelta(minutes=i)
         )
         for i in range(6)
     ]
@@ -112,7 +112,7 @@ async def test_get_product_review_list_handler_pagination_success(
     product = product_factory()
     reviews = [
         review_factory(
-            product=product, created_at=datetime.utcnow() + timedelta(minutes=i)
+            product=product, created_at=datetime.now(timezone.utc) + timedelta(minutes=i)
         )
         for i in range(6)
     ]
@@ -149,7 +149,7 @@ async def test_get_product_review_list_handler_unsupported_sort_field_bad_reques
     product = product_factory()
     reviews = [
         review_factory(
-            product=product, created_at=datetime.utcnow() + timedelta(minutes=i)
+            product=product, created_at=datetime.now(timezone.utc) + timedelta(minutes=i)
         )
         for i in range(6)
     ]

--- a/tests/factories/cart.py
+++ b/tests/factories/cart.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
 from app.database.models.cart import Cart
@@ -17,7 +17,7 @@ def cart_factory(user: User | None = None, **kwargs) -> Cart:
         id=kwargs.get("id", uuid4()),
         user=target_user,
         total_items=kwargs.get("total_items", 0),
-        created_at=kwargs.get("created_at", datetime.utcnow()),
+        created_at=kwargs.get("created_at", datetime.now(timezone.utc)),
     )
 
 

--- a/tests/factories/orders.py
+++ b/tests/factories/orders.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from uuid import uuid4
 
@@ -18,7 +18,7 @@ def order_factory(user: User | None = None, **kwargs) -> Order:
         user=target_user,
         status=kwargs.get("status", "pending"),
         total_price=kwargs.get("total_price", Decimal(0)),
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
     )
 
 

--- a/tests/factories/products.py
+++ b/tests/factories/products.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from random import randint
 from typing import List
@@ -26,7 +26,7 @@ def product_factory(
         description=kwargs.get("description", "product_description"),
         price=price if price is not None else randint(1, 10000),
         stock=stock if stock is not None else randint(1, 10000),
-        created_at=kwargs.get("created_at", datetime.utcnow()),
+        created_at=kwargs.get("created_at", datetime.now(timezone.utc)),
         product_rating=product_rating,
     )
 
@@ -52,7 +52,7 @@ def new_product_data_factory(
 
 
 def multiple_products_factory(count: int = 2) -> List[Product]:
-    base_time = datetime.utcnow()
+    base_time = datetime.now(timezone.utc)
     return [
         Product(
             id=uuid4(),

--- a/tests/factories/reviews.py
+++ b/tests/factories/reviews.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from random import randint
 from uuid import uuid4
 
@@ -19,7 +19,7 @@ def review_factory(
         product_rating=rating,
         user=user or user_factory(),
         product=product or product_factory(),
-        created_at=kwargs.get("created_at", datetime.utcnow()),
+        created_at=kwargs.get("created_at", datetime.now(timezone.utc)),
     )
 
 

--- a/tests/factories/users.py
+++ b/tests/factories/users.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 from app.database.models.user import User
@@ -19,7 +19,7 @@ def user_factory(
         last_name=kwargs.get("last_name", "last_name"),
         role=kwargs.get("role", "user"),
         password_hash=get_password_hash(password),
-        created_at=kwargs.get("created_at", datetime.utcnow()),
+        created_at=kwargs.get("created_at", datetime.now(timezone.utc)),
     )
 
 
@@ -41,5 +41,5 @@ def token_data_factory(
     return UserTokenData(
         sub=user.id,
         role=user.role,
-        exp=exp if exp is not None else datetime.utcnow() + timedelta(minutes=30),
+        exp=exp if exp is not None else datetime.now(timezone.utc) + timedelta(minutes=30),
     )

--- a/tests/repositories/test_product/test_repo_product_listing.py
+++ b/tests/repositories/test_product/test_repo_product_listing.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -10,7 +10,7 @@ from tests.factories.products import product_factory
 @pytest.mark.asyncio
 async def test_get_product_list_repo_without_cursor_success(db_session):
     products = [
-        product_factory(created_at=datetime.utcnow() + timedelta(minutes=i))
+        product_factory(created_at=datetime.now(timezone.utc) + timedelta(minutes=i))
         for i in range(4)
     ]
     db_session.add_all(products)
@@ -38,7 +38,7 @@ async def test_get_product_list_repo_without_cursor_success(db_session):
 @pytest.mark.asyncio
 async def test_get_product_list_repo_pagination_success(db_session):
     products = [
-        product_factory(created_at=datetime.utcnow() + timedelta(minutes=i))
+        product_factory(created_at=datetime.now(timezone.utc) + timedelta(minutes=i))
         for i in range(6)
     ]
     db_session.add_all(products)

--- a/tests/repositories/test_review/test_repo_review_listing.py
+++ b/tests/repositories/test_review/test_repo_review_listing.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -13,7 +13,7 @@ async def test_get_product_review_list_repo_without_cursor_success(db_session):
     product = product_factory()
     reviews = [
         review_factory(
-            product=product, created_at=datetime.utcnow() + timedelta(minutes=i)
+            product=product, created_at=datetime.now(timezone.utc) + timedelta(minutes=i)
         )
         for i in range(4)
     ]
@@ -44,7 +44,7 @@ async def test_get_product_review_list_repo_pagination_success(db_session):
     product = product_factory()
     reviews = [
         review_factory(
-            product=product, created_at=datetime.utcnow() + timedelta(minutes=i)
+            product=product, created_at=datetime.now(timezone.utc) + timedelta(minutes=i)
         )
         for i in range(6)
     ]

--- a/tests/services/test_review/test_services_review_listing.py
+++ b/tests/services/test_review/test_services_review_listing.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -14,7 +14,7 @@ async def test_get_product_review_list_serv_without_cursor_success(db_session):
     product = product_factory()
     reviews = [
         review_factory(
-            product=product, created_at=datetime.utcnow() + timedelta(minutes=i)
+            product=product, created_at=datetime.now(timezone.utc) + timedelta(minutes=i)
         )
         for i in range(6)
     ]
@@ -42,7 +42,7 @@ async def test_get_product_review_list_serv_pagination_success(db_session):
     product = product_factory()
     reviews = [
         review_factory(
-            product=product, created_at=datetime.utcnow() + timedelta(minutes=i)
+            product=product, created_at=datetime.now(timezone.utc) + timedelta(minutes=i)
         )
         for i in range(6)
     ]

--- a/tests/services/test_user/test_service_token.py
+++ b/tests/services/test_user/test_service_token.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from freezegun import freeze_time
 from jose import jwt
@@ -23,7 +23,7 @@ def test_create_access_token_with_expires(monkeypatch, test_settings):
 
     assert decoded["sub"] == "email"
     assert decoded["exp"] == int(
-        (datetime.utcnow() + timedelta(minutes=30)).timestamp()
+        (datetime.now(timezone.utc) + timedelta(minutes=30)).timestamp()
     )
 
 
@@ -40,5 +40,5 @@ def test_create_access_token_default_expires(monkeypatch, test_settings):
     )
 
     assert decoded["exp"] == int(
-        (datetime.utcnow() + timedelta(minutes=15)).timestamp()
+        (datetime.now(timezone.utc) + timedelta(minutes=15)).timestamp()
     )


### PR DESCRIPTION
- Перевёл всё время в UTC для точности и определённости.
- Везде вызовы устаревшего datetime.utcnow() заменены на datetime.now(timezone.utc).
- Для базы написана миграция с SET LOCAL timezone = 'utc' для мгновенного изменения типа без блокировок.